### PR TITLE
Add ability to use regular expressions for file names

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ SimpleReplace.prototype._processPattern = function(pattern) {
   if (type === 'function') {
     return pattern;
   }
-  throw new Error('include/exclude patterns can be a RegExp, glob string, or function. You supplied `' + typeof pattern +'`.');
+  throw new Error('files patterns can be a RegExp, glob string, or function. You supplied `' + typeof pattern +'`.');
 };
 
 SimpleReplace.prototype.canProcessFile = function (relativePath) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 var Filter = require('broccoli-filter');
 
+function isMatchedArray(arr, target) {
+  return arr.filter(function(x) {
+    return target.match(x);
+  }).length > 0;
+}
+
 function SimpleReplace (inputTree, options) {
   if (!(this instanceof SimpleReplace)) return new SimpleReplace(inputTree, options);
 
@@ -25,6 +31,8 @@ SimpleReplace.prototype.constructor = SimpleReplace;
 
 SimpleReplace.prototype.canProcessFile = function (relativePath) {
   if (this.files.indexOf(relativePath) > -1) {
+    return true;
+  } else if (isMatchedArray(this.files, relativePath)) {
     return true;
   } else {
     return null;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,10 @@ SimpleReplace.prototype._processPattern = function(pattern) {
   if (type === 'string') {
     return new Minimatch(pattern);
   }
-  throw new Error('include/exclude patterns can be a RegExp, or glob string. You supplied `' + typeof pattern +'`.');
+  if (type === 'function') {
+    return pattern;
+  }
+  throw new Error('include/exclude patterns can be a RegExp, glob string, or function. You supplied `' + typeof pattern +'`.');
 };
 
 SimpleReplace.prototype.canProcessFile = function (relativePath) {
@@ -42,6 +45,8 @@ SimpleReplace.prototype.canProcessFile = function (relativePath) {
       return pattern.test(relativePath);
     } else if (pattern instanceof Minimatch) {
       return pattern.match(relativePath);
+    } else if (typeof pattern === 'function') {
+      return pattern(relativePath);
     }
     return false;
   }).length;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "javascript"
   ],
   "dependencies": {
-    "broccoli-filter": "~0.1.6"
+    "broccoli-filter": "~0.1.6",
+    "minimatch": "^2.0.8"
   },
   "devDependencies": {
     "mocha": "~1.18.2",

--- a/tests/index.js
+++ b/tests/index.js
@@ -53,6 +53,44 @@ describe('broccoli-simple-replace', function(){
     });
   })
 
+  it('can use a glob in files', function(){
+    var sourcePath = 'tests/fixtures/string-for-string';
+    var tree = replace(sourcePath, {
+      files: [ '*.js' ],
+      pattern: {
+        match: 'REPLACE_ME',
+        replacement: 'REPLACED!!!'
+      }
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(dir) {
+      var actual = fs.readFileSync(dir + '/matched-file.js', { encoding: 'utf8'});
+      var expected = 'ZOMG, ZOMG\n\nREPLACED!!!\n\nZOMG, ZOMG\n';
+
+      expect(actual).to.equal(expected);
+    });
+  })
+
+  it('can use a function in files', function(){
+    var sourcePath = 'tests/fixtures/string-for-string';
+    var tree = replace(sourcePath, {
+      files: [ function(x) { return 'matched.js'; }  ],
+      pattern: {
+        match: 'REPLACE_ME',
+        replacement: 'REPLACED!!!'
+      }
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(dir) {
+      var actual = fs.readFileSync(dir + '/matched-file.js', { encoding: 'utf8'});
+      var expected = 'ZOMG, ZOMG\n\nREPLACED!!!\n\nZOMG, ZOMG\n';
+
+      expect(actual).to.equal(expected);
+    });
+  })
+
   it('can accept a regex matcher', function(){
     var sourcePath = 'tests/fixtures/string-for-string';
     var tree = replace(sourcePath, {

--- a/tests/index.js
+++ b/tests/index.js
@@ -72,10 +72,10 @@ describe('broccoli-simple-replace', function(){
     });
   })
 
-  it('can use a function in files', function(){
+  it('can use a function in files to find match', function(){
     var sourcePath = 'tests/fixtures/string-for-string';
     var tree = replace(sourcePath, {
-      files: [ function(x) { return 'matched.js'; }  ],
+      files: [ function(x) { return x.indexOf('matched') > -1; }  ],
       pattern: {
         match: 'REPLACE_ME',
         replacement: 'REPLACED!!!'
@@ -86,6 +86,25 @@ describe('broccoli-simple-replace', function(){
     return builder.build().then(function(dir) {
       var actual = fs.readFileSync(dir + '/matched-file.js', { encoding: 'utf8'});
       var expected = 'ZOMG, ZOMG\n\nREPLACED!!!\n\nZOMG, ZOMG\n';
+
+      expect(actual).to.equal(expected);
+    });
+  })
+
+  it('can use function in files to not match', function(){
+    var sourcePath = 'tests/fixtures/string-for-string';
+    var tree = replace(sourcePath, {
+      files: [ function(x) { return x.indexOf('no-match') > -1; }  ],
+      pattern: {
+        match: 'REPLACE_ME',
+        replacement: 'REPLACED!!!'
+      }
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(dir) {
+      var actual = fs.readFileSync(dir + '/matched-file.js', { encoding: 'utf8'});
+      var expected = 'ZOMG, ZOMG\n\nREPLACE_ME\n\nZOMG, ZOMG\n';
 
       expect(actual).to.equal(expected);
     });

--- a/tests/index.js
+++ b/tests/index.js
@@ -34,6 +34,25 @@ describe('broccoli-simple-replace', function(){
     });
   })
 
+  it('can use a regular expression in files', function(){
+    var sourcePath = 'tests/fixtures/string-for-string';
+    var tree = replace(sourcePath, {
+      files: [ new RegExp('matched' + '(.*js)') ],
+      pattern: {
+        match: 'REPLACE_ME',
+        replacement: 'REPLACED!!!'
+      }
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(dir) {
+      var actual = fs.readFileSync(dir + '/matched-file.js', { encoding: 'utf8'});
+      var expected = 'ZOMG, ZOMG\n\nREPLACED!!!\n\nZOMG, ZOMG\n';
+
+      expect(actual).to.equal(expected);
+    });
+  })
+
   it('can accept a regex matcher', function(){
     var sourcePath = 'tests/fixtures/string-for-string';
     var tree = replace(sourcePath, {


### PR DESCRIPTION
Addresses issue #1 

This allows the you to something like:

``` javascript
var replace = require('broccoli-string-replace');

var tree = replace('app', {
  files: [ new RegExp(appName + '(.*js)') ], // will find fingerprinted version
  pattern: {
    match: /VERSION_STRING/g,
    replacement: '1.6.5'
  }
});
```

My main use case was being able to use it on the `app` and `vendor` files during the build process, so it can work on fingerprinted files.

Added a test for good measure.
