### PR TITLE
prefer broccoli-persistent-filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Filter = require('broccoli-filter');
+var Filter = require('broccoli-persistent-filter');
 var Minimatch = require('minimatch').Minimatch;
 
 function SimpleReplace (inputTree, options) {
@@ -22,6 +22,7 @@ function SimpleReplace (inputTree, options) {
     this.patterns = [];
   }
 };
+
 SimpleReplace.prototype = Object.create(Filter.prototype);
 SimpleReplace.prototype.constructor = SimpleReplace;
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "javascript"
   ],
   "dependencies": {
-    "broccoli-filter": "~0.1.6",
+    "broccoli-persistent-filter": "^1.1.5",
     "minimatch": "^2.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
- don’t enable the persistent part (because this part isn’t a perf issue)
- benefit from the patch-based outputDir management 
